### PR TITLE
removed encoding step

### DIFF
--- a/syllabify.py
+++ b/syllabify.py
@@ -104,7 +104,7 @@ def write_output(syllabifiedlines, outputfile, delim):
         for line in syllabifiedlines:
             words = []
             for word in line:
-                words.append(delim.join(word).encode("utf8"))
+                words.append(delim.join(word)) 
             f.write(" ".join(words))
             if words:
                 f.write("\n")


### PR DESCRIPTION
Removed the explicit need to encode the output string that was a remnant of python 2. Python 3 encodes in utf8 by default.